### PR TITLE
로그인 인증을 위한 토큰 저장 방식 변경

### DIFF
--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -16,6 +16,12 @@ export function Middleware(
           return req;
         case 'cookies':
           return req.cookies[value];
+        case 'authorization':
+          if (!req.headers.authorization) {
+            return null;
+          }
+
+          return req.headers.authorization.split(`${value} `)[1];
       }
     });
 
@@ -51,5 +57,16 @@ export function Cookies(key: string) {
     }
 
     target.extractors.unshift({ type: 'cookies', value: key });
+  };
+}
+
+export function Auth(type: string) {
+  // eslint-disable-next-line
+  return function (target: any, propertyKey: string, parameterIndex: number) {
+    if (!target.extractors) {
+      target.extractors = [];
+    }
+
+    target.extractors.unshift({ type: 'authorization', value: type });
   };
 }

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -6,15 +6,12 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import type { Response, Request } from 'express';
-import { Cookies, Middleware, Req } from '@/decorators';
+import { Middleware, Req, Auth } from '@/decorators';
 import { tokenService } from '@/utils/token.service';
 
 class ValidationMiddlewars {
   @Middleware
-  verifyUser(
-    @Cookies('accessToken') accessToken: string,
-    @Req req: Request,
-  ): boolean {
+  verifyUser(@Auth('Bearer') accessToken: string, @Req req: Request): boolean {
     const decoded = tokenService.decodeToken(accessToken);
 
     if (!decoded) {

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -84,6 +84,7 @@ export class AuthController {
   })
   @ApiOperation({
     summary: '로그인 인증에 사용되는 accessToken 쿠키를 삭제합니다.',
+    deprecated: true,
   })
   @Get('logout')
   @UseGuards(AuthGuard)

--- a/src/swagger.document.ts
+++ b/src/swagger.document.ts
@@ -8,6 +8,7 @@ export class BaseAPIDocument {
       .setTitle('TOJ API Spec')
       .setDescription('Type-challenges Online Judge의 API 명세입니다.')
       .setVersion('0.0.1')
+      .addBearerAuth()
       .build();
   }
 }


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 기존 쿠키로 관리하던 로그인 인증 토큰을 Authorization 헤더로 관리하도록 변경하는 작업입니다.
- #25 

<br/>

### 📝 변경 사항

- 인증을 확인하는 `auth.guard.ts`
- `auth/login` api 서비스 로직 수정
- Bearer type Authorization을 swagger에서 사용할 수 있도록 swagger 설정

<br/>

### 📷 스크린 샷

![image](https://github.com/type-challenges-online-judge/toj-be/assets/44913775/e027288f-227e-45c4-b418-64aafd659dab)

swagger에서 자물쇠가 포함된 API는 Bearer type의 Authorization 토큰을 담아 요청해야 함을 의미합니다.

클릭 시 직접 로그인 인증 jwt 토큰을 Bearer type으로 authorization 헤더에 담아 테스트 해볼 수 있습니다.

<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 집중적으로 리뷰해주었으면 하는 부분 설명

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
