### PR TITLE
제출 현황 페이지를 구성하기 위한 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { dataSourceOptions } from '@/models/data-source';
 import { AuthModule } from './modules/auth/auth.module';
 import { UserModule } from './modules/user/user.module';
+import { SubmitModule } from './modules/submit/submit.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { UserModule } from './modules/user/user.module';
     ProblemModule,
     AuthModule,
     UserModule,
+    SubmitModule,
   ],
   controllers: [],
   providers: [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { RequestMethod, ValidationPipe } from '@nestjs/common';
 import { AuthModule } from './modules/auth/auth.module';
 import { UserModule } from './modules/user/user.module';
 import cookieParser = require('cookie-parser');
+import { SubmitModule } from './modules/submit/submit.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -51,7 +52,7 @@ async function bootstrap() {
     .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config, {
-    include: [ProblemModule, AuthModule, UserModule],
+    include: [ProblemModule, AuthModule, UserModule, SubmitModule],
   });
   SwaggerModule.setup('api', app, document);
 

--- a/src/modules/submit/dto/SubmitCodePaging.dto.ts
+++ b/src/modules/submit/dto/SubmitCodePaging.dto.ts
@@ -1,0 +1,20 @@
+import { SubmitCodeSearchOptions } from './SubmitCodeSearchOptions.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class SubmitCodePaging extends SubmitCodeSearchOptions {
+  @ApiProperty({
+    required: true,
+    description:
+      '확인하려는 페이지의 번호(1 ~ ⌈조건에 맞는 게시글 수 /  `pagePerCount`⌉)입니다.',
+  })
+  @IsNumber()
+  pageNum: number;
+
+  @ApiProperty({
+    required: true,
+    description: '페이지당 확인 할 게시글 수 입니다.',
+  })
+  @IsNumber()
+  countPerPage: number;
+}

--- a/src/modules/submit/dto/SubmitCodeSearchOptions.dto.ts
+++ b/src/modules/submit/dto/SubmitCodeSearchOptions.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class SubmitCodeSearchOptions {
+  @ApiProperty({
+    required: false,
+    description: '특정 문제의 제출 내역을 보고 싶을 때 사용합니다.',
+  })
+  @IsNumber()
+  problemId: number;
+
+  @ApiProperty({
+    required: false,
+    description: '특정 사용자의 제출 내역을 보고 싶을 때 사용합니다.',
+  })
+  @IsNumber()
+  snsId: number;
+}

--- a/src/modules/submit/dto/SubmitCodeSearchOptions.dto.ts
+++ b/src/modules/submit/dto/SubmitCodeSearchOptions.dto.ts
@@ -1,18 +1,20 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber } from 'class-validator';
+import { IsOptional, IsNumber } from 'class-validator';
 
 export class SubmitCodeSearchOptions {
   @ApiProperty({
     required: false,
     description: '특정 문제의 제출 내역을 보고 싶을 때 사용합니다.',
   })
+  @IsOptional()
   @IsNumber()
-  problemId: number;
+  problemId: number | undefined;
 
   @ApiProperty({
     required: false,
     description: '특정 사용자의 제출 내역을 보고 싶을 때 사용합니다.',
   })
+  @IsOptional()
   @IsNumber()
-  snsId: number;
+  snsId: number | undefined;
 }

--- a/src/modules/submit/dto/index.ts
+++ b/src/modules/submit/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './SubmitCodePaging.dto';
+export * from './SubmitCodeSearchOptions.dto';

--- a/src/modules/submit/submit.controller.ts
+++ b/src/modules/submit/submit.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiSubmitCodeList, ApiSubmitCodeListSize } from './swagger';
+import { SubmitService } from './submit.service';
+import { AuthGuard } from '@/guards';
+import { SubmitCodePaging, SubmitCodeSearchOptions } from './dto';
+
+@ApiTags('submit')
+@Controller('submit')
+export class SubmitController {
+  constructor(private readonly submitService: SubmitService) {}
+
+  @ApiSubmitCodeList()
+  @UseGuards(AuthGuard)
+  @Get()
+  async getSubmitCodeList(@Query() query: SubmitCodePaging) {
+    return await this.submitService.getSubmitCodeList(query);
+  }
+
+  @ApiSubmitCodeListSize()
+  @UseGuards(AuthGuard)
+  @Get('size')
+  async getSubmitCodeListLength(@Query() query: SubmitCodeSearchOptions) {
+    return await this.submitService.getSubmitCodeListSize(query);
+  }
+}

--- a/src/modules/submit/submit.controller.ts
+++ b/src/modules/submit/submit.controller.ts
@@ -1,9 +1,9 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiSubmitCodeList, ApiSubmitCodeListSize } from './swagger';
 import { SubmitService } from './submit.service';
-import { AuthGuard } from '@/guards';
 import { SubmitCodePaging, SubmitCodeSearchOptions } from './dto';
+import { responseTemplate } from '@/utils';
 
 @ApiTags('submit')
 @Controller('submit')
@@ -11,16 +11,25 @@ export class SubmitController {
   constructor(private readonly submitService: SubmitService) {}
 
   @ApiSubmitCodeList()
-  @UseGuards(AuthGuard)
   @Get()
   async getSubmitCodeList(@Query() query: SubmitCodePaging) {
-    return await this.submitService.getSubmitCodeList(query);
+    const submitList = await this.submitService.getSubmitCodeList(query);
+
+    return responseTemplate(
+      '성공적으로 제출 리스트를 조회했습니다.',
+      submitList,
+    );
   }
 
   @ApiSubmitCodeListSize()
-  @UseGuards(AuthGuard)
   @Get('size')
   async getSubmitCodeListLength(@Query() query: SubmitCodeSearchOptions) {
-    return await this.submitService.getSubmitCodeListSize(query);
+    const submitListSize =
+      await this.submitService.getSubmitCodeListSize(query);
+
+    return responseTemplate(
+      '성공적으로 제출 리스트의 개수를 조회했습니다.',
+      submitListSize,
+    );
   }
 }

--- a/src/modules/submit/submit.module.ts
+++ b/src/modules/submit/submit.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SubmitController } from './submit.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SubmitCode } from '@/models/entities';
+import { SubmitService } from './submit.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SubmitCode])],
+  controllers: [SubmitController],
+  providers: [SubmitService],
+})
+export class SubmitModule {}

--- a/src/modules/submit/submit.service.ts
+++ b/src/modules/submit/submit.service.ts
@@ -54,7 +54,7 @@ export class SubmitService {
       };
     }
 
-    const length = await this.repo.findAndCount({
+    const length = await this.repo.count({
       where,
     });
 

--- a/src/modules/submit/submit.service.ts
+++ b/src/modules/submit/submit.service.ts
@@ -1,0 +1,63 @@
+import { SubmitCode } from '@/models/entities';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SubmitCodePaging, SubmitCodeSearchOptions } from './dto';
+import type { FindOptionsWhere } from 'typeorm';
+
+@Injectable()
+export class SubmitService {
+  constructor(
+    @InjectRepository(SubmitCode) private readonly repo: Repository<SubmitCode>,
+  ) {}
+
+  async getSubmitCodeList(options: SubmitCodePaging) {
+    const { problemId, snsId, pageNum, countPerPage } = options;
+
+    const where: FindOptionsWhere<SubmitCode> = {};
+
+    if (problemId) {
+      where.problem = {
+        id: problemId,
+      };
+    }
+
+    if (snsId) {
+      where.user = {
+        snsId,
+      };
+    }
+
+    const submitCodeList = await this.repo.find({
+      where,
+      skip: countPerPage * (pageNum - 1),
+      take: countPerPage,
+    });
+
+    return submitCodeList;
+  }
+
+  async getSubmitCodeListSize(options: SubmitCodeSearchOptions) {
+    const { problemId, snsId } = options;
+
+    const where: FindOptionsWhere<SubmitCode> = {};
+
+    if (problemId) {
+      where.problem = {
+        id: problemId,
+      };
+    }
+
+    if (snsId) {
+      where.user = {
+        snsId,
+      };
+    }
+
+    const length = await this.repo.findAndCount({
+      where,
+    });
+
+    return length;
+  }
+}

--- a/src/modules/submit/swagger/ApiSubmitCodeList.swagger.ts
+++ b/src/modules/submit/swagger/ApiSubmitCodeList.swagger.ts
@@ -1,0 +1,12 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+
+export const ApiSubmitCodeList = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '조건과 일치하는 제출 목록의 리스트를 반환합니다.',
+    }),
+    ApiOkResponse({}),
+    ApiBearerAuth(),
+  );
+};

--- a/src/modules/submit/swagger/ApiSubmitCodeList.swagger.ts
+++ b/src/modules/submit/swagger/ApiSubmitCodeList.swagger.ts
@@ -1,12 +1,38 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 export const ApiSubmitCodeList = () => {
   return applyDecorators(
     ApiOperation({
       summary: '조건과 일치하는 제출 목록의 리스트를 반환합니다.',
     }),
-    ApiOkResponse({}),
-    ApiBearerAuth(),
+    ApiOkResponse({
+      description: '성공적으로 제출 리스트를 조회했습니다.',
+      schema: {
+        example: {
+          message: '성공적으로 제출 리스트를 조회했습니다.',
+          data: [
+            {
+              createdAt: '2023-09-29T01:31:36.779Z',
+              updatedAt: '2023-09-29T01:31:46.976Z',
+              id: 83,
+              code: 'type MyPick<T, K extends keyof T> = {[key in K]: T[key]}',
+              isHidden: false,
+              correct_score: 100,
+              valid_score: 100,
+            },
+            {
+              createdAt: '2023-09-29T01:32:05.227Z',
+              updatedAt: '2023-09-29T01:32:14.689Z',
+              id: 84,
+              code: 'type MyPick<T, K extends keyof T> = any',
+              isHidden: false,
+              correct_score: 0,
+              valid_score: 100,
+            },
+          ],
+        },
+      },
+    }),
   );
 };

--- a/src/modules/submit/swagger/ApiSubmitCodeListSize.swagger.ts
+++ b/src/modules/submit/swagger/ApiSubmitCodeListSize.swagger.ts
@@ -1,0 +1,12 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+
+export const ApiSubmitCodeListSize = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '조건과 일치하는 제출 목록의 리스트의 개수를 반환합니다.',
+    }),
+    ApiOkResponse({}),
+    ApiBearerAuth(),
+  );
+};

--- a/src/modules/submit/swagger/ApiSubmitCodeListSize.swagger.ts
+++ b/src/modules/submit/swagger/ApiSubmitCodeListSize.swagger.ts
@@ -1,12 +1,19 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 export const ApiSubmitCodeListSize = () => {
   return applyDecorators(
     ApiOperation({
       summary: '조건과 일치하는 제출 목록의 리스트의 개수를 반환합니다.',
     }),
-    ApiOkResponse({}),
-    ApiBearerAuth(),
+    ApiOkResponse({
+      description: '성공적으로 제출 리스트의 개수를 조회했습니다.',
+      schema: {
+        example: {
+          message: '성공적으로 제출 리스트의 개수를 조회했습니다.',
+          data: 2,
+        },
+      },
+    }),
   );
 };

--- a/src/modules/submit/swagger/index.ts
+++ b/src/modules/submit/swagger/index.ts
@@ -1,0 +1,2 @@
+export * from './ApiSubmitCodeList.swagger';
+export * from './ApiSubmitCodeListSize.swagger';


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 제출된 코드 내역을 조건(`사용자 별`, `문제 별`)에 맞게 조회할 수 있는 API를 구현합니다.
- #39 

<br/>

### 📝 변경 사항

`submit` 도메인 모듈이 생성되었고, 아래 두 가지 API가 생성되었습니다.

- 조건과 일치하는 제출 코드 내역을 조회하는 API
- 조건과 일치하는 제출된 코드 내역의 개수를 조회하는 API

<br/>

### 📷 스크린 샷 (선택)

- 관련 스크린샷 첨부

<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 집중적으로 리뷰해주었으면 하는 부분 설명

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
