### PR TITLE
채점 시스템 과부하 문제 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/schedule": "^3.0.4",
         "@nestjs/swagger": "^7.1.11",
         "@nestjs/typeorm": "^10.0.0",
         "@octokit/types": "^11.1.0",
@@ -1610,6 +1611,20 @@
         "@nestjs/core": "^10.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-3.0.4.tgz",
+      "integrity": "sha512-uFJpuZsXfpvgx2y7/KrIZW9e1L68TLiwRodZ6+Gc8xqQiHSUzAVn+9F4YMxWFlHITZvvkjWziUFgRNCitDcTZQ==",
+      "dependencies": {
+        "cron": "2.4.3",
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.12"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.0.2.tgz",
@@ -2412,6 +2427,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.2.tgz",
+      "integrity": "sha512-l5cpE57br4BIjK+9BSkFBOsWtwv6J9bJpC7gdXIzZyI0vuKvNTk0wZZrkQxMGsUAuGW9+WMNWF2IJMD7br2yeQ=="
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -4000,6 +4020,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-2.4.3.tgz",
+      "integrity": "sha512-YBvExkQYF7w0PxyeFLRyr817YVDhGxaCi5/uRRMqa4aWD3IFKRd+uNbpW1VWMdqQy8PZ7CElc+accXJcauPKzQ==",
+      "dependencies": {
+        "@types/luxon": "~3.3.0",
+        "luxon": "~3.3.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6681,6 +6710,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/macos-release": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^3.0.4",
     "@nestjs/swagger": "^7.1.11",
     "@nestjs/typeorm": "^10.0.0",
     "@octokit/types": "^11.1.0",

--- a/src/modules/submit/submit.controller.ts
+++ b/src/modules/submit/submit.controller.ts
@@ -90,11 +90,7 @@ export class SubmitController {
      */
     const testCases = await this.problemService.getTestCases(problemId);
 
-    try {
-      this.submitService.startJudge(submitCodeId, problem, testCases);
-    } catch (e) {
-      console.log(e);
-    }
+    this.submitService.enqueueJudgeItem({ submitCodeId, problem, testCases });
 
     return responseTemplate('정답 제출이 완료되어 채점이 시작되었습니다.', {
       submitCodeId,

--- a/src/modules/submit/submit.module.ts
+++ b/src/modules/submit/submit.module.ts
@@ -7,9 +7,15 @@ import { ProblemService } from '@/modules/problem/problem.service';
 import { ProblemModule } from '@/modules/problem/problem.module';
 import { UserService } from '@/modules/user/user.service';
 import { UserModule } from '@/modules/user/user.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
-  imports: [UserModule, ProblemModule, TypeOrmModule.forFeature([SubmitCode])],
+  imports: [
+    UserModule,
+    ProblemModule,
+    TypeOrmModule.forFeature([SubmitCode]),
+    ScheduleModule.forRoot(),
+  ],
   controllers: [SubmitController],
   providers: [SubmitService, ProblemService, UserService],
 })

--- a/src/modules/submit/submit.service.ts
+++ b/src/modules/submit/submit.service.ts
@@ -6,7 +6,6 @@ import { SubmitCodePaging, SubmitCodeSearchOptions } from './dto';
 import { SubmitCode } from '@/modules/submit/entities';
 import { Problem } from '@/modules/problem/entities';
 import { User } from '@/modules/user/entities';
-import { TestCase } from '@/modules/problem/entities';
 import { SCORE_STATE } from '@/constants';
 import {
   createKeyOfJudgeStatus,
@@ -16,12 +15,7 @@ import {
 import { JudgeStatus } from '@/types/judge';
 import { TEST_CASE_TYPE } from '@/constants';
 import { Interval } from '@nestjs/schedule';
-
-type JudgeItem = {
-  submitCodeId: number;
-  problem: Problem;
-  testCases: TestCase[];
-};
+import type { JudgeItem } from '@/types/judge';
 
 @Injectable()
 export class SubmitService {

--- a/src/types/judge.d.ts
+++ b/src/types/judge.d.ts
@@ -6,3 +6,9 @@ export type JudgeStatus = {
   currentTestCase?: number;
   totalTestCaseLength?: number;
 };
+
+export type JudgeItem = {
+  submitCodeId: number;
+  problem: Problem;
+  testCases: TestCase[];
+};


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 채점 시스템이 과부하 되어 채점 결과에 영향을 미치는 부분을 수정합니다.
- #47 

<br/>

### 📝 변경 사항

- 채점 시스템이 동시에 현재 최대 `2`개의 채점만 처리하도록 구현하였습니다.
  - cloudtype의 환경은 NestJS + PostgreSQL 두 가지 이미지가 동작하고 있는 환경에서, 1GB 메모리 램 뿐이 주어진 환경이기 때문에 동시에 처리 가능한 채점 개수를 낮게 설정하였습니다.
- 더 나은 배포 환경으로 이주함에 따라 동시에 처리 가능한 채점 개수를 늘려나갈 생각입니다.

<br/>

### 📷 스크린 샷 (선택)

![스크린샷 2023-10-01 230348](https://github.com/type-challenges-online-judge/toj-be/assets/44913775/b43aa525-5c72-4746-adf6-42e10f90da83)
- 1분에 걸쳐 약 25개의 제출을 한 후 모두 올바르게 채점이 된 것을 확인할 수 있었습니다. (마지막 3개도 추후 정상적으로 채점됨)
- 동시에 `2`개밖에 채점하지 못하기 때문에, 채점 속도가 매우 느리지만 안정적으로 채점됩니다.

<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 집중적으로 리뷰해주었으면 하는 부분 설명

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
