### PR TITLE
type-challenges 문제의 테스트케이스 올바르게 추출

### DIFF
--- a/src/utils/template/index.ts
+++ b/src/utils/template/index.ts
@@ -18,7 +18,7 @@ export const createCorrectTestCases = async (
   const ret: TestCase[] = [];
 
   const correctRegExp =
-    /Expect\s*<\s*(Equal|Alike)\s*<(.|\n)*?(>\s*){2,},{0,1}/g;
+    /(Expect(True|False){0,1}|Is(True|False){1})\s*<\s*(Equal|Alike|ExpectExtends|IsAny|NotAny)\s*<(.|\n)*?(>\s*){2,},{0,1}/g;
 
   const correctTestTemplate = template.replaceAll(
     '// @ts-expect-error',
@@ -64,7 +64,7 @@ export const createValidTestCases = async (
   const ret: TestCase[] = [];
 
   const correctRegExp =
-    /Expect\s*<\s*(Equal|Alike)\s*<(.|\n)*?(>\s*){2,},{0,1}/g;
+    /(Expect(True|False){0,1}|Is(True|False){1})\s*<\s*(Equal|Alike|ExpectExtends|IsAny|NotAny)\s*<(.|\n)*?(>\s*){2,},{0,1}/g;
 
   const validTestTemplate = template.replaceAll(correctRegExp, '');
 


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 타입 챌린지 문제의 테스트케이스들을 올바르게 추출하도록 정규식을 수정합니다.
- #56

<br/>

### 📝 변경 사항

```ts
// type-challenges/utils/index.d.ts

export type Expect<T extends true> = T
export type ExpectTrue<T extends true> = T
export type ExpectFalse<T extends false> = T
export type IsTrue<T extends true> = T
export type IsFalse<T extends false> = T

export type Equal<X, Y> =
  (<T>() => T extends X ? 1 : 2) extends
  (<T>() => T extends Y ? 1 : 2) ? true : false
export type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true

// https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
export type IsAny<T> = 0 extends (1 & T) ? true : false
export type NotAny<T> = true extends IsAny<T> ? false : true

export type Debug<T> = { [K in keyof T]: T[K] }
export type MergeInsertions<T> =
  T extends object
    ? { [K in keyof T]: MergeInsertions<T[K]> }
    : T

export type Alike<X, Y> = Equal<MergeInsertions<X>, MergeInsertions<Y>>

export type ExpectExtends<VALUE, EXPECTED> = EXPECTED extends VALUE ? true : false
export type ExpectValidArgs<FUNC extends (...args: any[]) => any, ARGS extends any[]> = ARGS extends Parameters<FUNC>
  ? true
  : false

export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
```
타입 챌린지에 사용되는 유틸 함수에서 `Debug`, `ExpectValidArgs`, `UnionToIntersection`을 제외한 나머지 유틸 함수들을 가져올 수 있도록 정규식을 수정합니다. (용도는 잘 모르겠으나, 문제에 전혀 포함되어 있지 않은 타입이었습니다.)

<br/>

### 📷 스크린 샷 (선택)

- 관련 스크린샷 첨부

<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 집중적으로 리뷰해주었으면 하는 부분 설명

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
