### PR TITLE
API 명세(Swagger)에 용도(개발, 운영)를 표시

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './modules/auth/auth.module';
 import { UserModule } from './modules/user/user.module';
 import cookieParser = require('cookie-parser');
 import { SubmitModule } from './modules/submit/submit.module';
+import { configService } from './config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -46,7 +47,9 @@ async function bootstrap() {
    * swagger 관련 설정
    */
   const config = new DocumentBuilder()
-    .setTitle('TOJ API Spec')
+    .setTitle(
+      `TOJ API Spec ${configService.isProduction() ? '(PROD)' : '(DEV)'}`,
+    )
     .setDescription('Type-challenges Online Judge의 API 명세입니다.')
     .setVersion('0.0.1')
     .addBearerAuth()


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 주소만 가지고 개발용 API 문서인지, 운영용 API 문서인지 구분을 잘 할수 없었던 문제를 해결합니다.
- #62 

<br/>

### 📝 변경 사항

- `src/main.ts` 의 swagger config가 수정되었습니다.

<br/>

### 📷 스크린 샷 (선택)

![image](https://github.com/type-challenges-online-judge/toj-be/assets/44913775/3198ebfb-0d55-4399-a87d-239b3193cb6c)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 집중적으로 리뷰해주었으면 하는 부분 설명

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
